### PR TITLE
Rescale features to preserve variance

### DIFF
--- a/model/wavenet.py
+++ b/model/wavenet.py
@@ -85,7 +85,7 @@ class Block(tf.keras.Model):
         gate = tf.math.sigmoid(x[..., self.channels:])
         x = context * gate
         # [B, T, C]
-        residual = self.proj_res(x) + inputs if not self.last else None
+        residual = (self.proj_res(x) + inputs) / 2**0.5 if not self.last else None
         skip = self.proj_skip(x)
         return residual, skip
 
@@ -160,7 +160,7 @@ class WaveNet(tf.keras.Model):
             x, skip = block(x, embed, mel)
             context.append(skip)
         # [B, T, C]
-        context = tf.reduce_sum(context, axis=0)
+        context = tf.reduce_sum(context, axis=0) / len(self.blocks)**0.5
         # [B, T, 1]
         for proj in self.proj_out:
             context = proj(context)


### PR DESCRIPTION
In my experience, this change produces a smoother loss curve and somewhat reduces time to convergence. The idea is that you'll end up with increasing feature variance for each sum so these divisions bring the features back to their original scale.